### PR TITLE
Toggle option to change camera view

### DIFF
--- a/ui-admin/src/create.js
+++ b/ui-admin/src/create.js
@@ -1,4 +1,5 @@
 import Agent from "./Agent";
+import Phaser from "phaser";
 
 export default function create() {
   this.fieldMapTileMap = this.make.tilemap({ key: "field-map" });
@@ -17,8 +18,16 @@ export default function create() {
   const playerSprite = this.add.sprite(0, 0, "player");
   playerSprite.scale = 3;
   playerSprite.setDepth(6);
-  this.cameras.main.startFollow(playerSprite, true);
-  this.cameras.main.setFollowOffset(-playerSprite.width, -playerSprite.height);
+  this.cursors = this.input.keyboard.createCursorKeys();
+  this.addPlantKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.S);
+  this.removePlantKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D);
+  this.randomDestinationKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.R);
+  
+  this.cKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.C);
+  this.playerView = true;
+
+  // Add an event listener for when the 'C' key is just pressed
+  this.cKey.on('down', togglePlayerView, this);
 
   const agentId = "agent1";
 
@@ -50,4 +59,35 @@ export default function create() {
 
   // EXPOSE TO EXTENSION
   window.__GRID_ENGINE__ = this.gridEngine;
+
+  function togglePlayerView() {
+    // Toggle the playerView value
+    this.playerView = !this.playerView;
+
+    if (this.playerView) {
+      this.cameras.main.startFollow(playerSprite, true);
+      this.cameras.main.setFollowOffset(-playerSprite.width, -playerSprite.height);
+    }
+    else if (!this.playerView) {
+
+      this.cameras.main.zoom = 0.85;
+  
+      const controlConfig = {
+          camera: this.cameras.main,
+          left: this.cursors.left,
+          right: this.cursors.right,
+          up: this.cursors.up,
+          down: this.cursors.down,
+          zoomIn: this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.Q),
+          zoomOut: this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.E),
+          acceleration: 0.06,
+          drag: 0.0005,
+          maxSpeed: 1.0
+      };
+  
+      this.controls = new Phaser.Cameras.Controls.SmoothedKeyControl(controlConfig);
+    }
+
+  }
+
 };

--- a/ui-admin/src/update.js
+++ b/ui-admin/src/update.js
@@ -1,71 +1,71 @@
 import Phaser from "phaser";
 
-export default function update() {
-  const cursors = this.input.keyboard.createCursorKeys();
+export default function update(time, delta) {
 
-  const addPlantKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.S);
-  const removePlantKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.D);
-  const randomDestinationKey = this.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.R);
-
-  if(randomDestinationKey.isDown) {
+  if(this.randomDestinationKey.isDown) {
     this.gridEngine.moveTo("player", { x: 15, y: 18 });
   }
 
-  if (addPlantKey.isDown) {
-    const playerPosition = this.gridEngine.getPosition("player");
-    const tileX = playerPosition.x;
-    const tileY = playerPosition.y;
-
-    // Get the grass layer
-    const grassLayer = this.fieldMapTileMap.layers[0].tilemapLayer;
-
-    // Check if there's a grass tile at the character's position and it has the property 'plantable'
-    const grassTile = grassLayer.getTileAt(tileX, tileY);
-
-    if (grassTile && grassTile.properties.plantable) {
-      // Check if there's no tile at the character's position in other layers
-      const noOtherTile = this.fieldMapTileMap.layers.every((layer, index) => {
-        if (index === 0) return true; // Skip the grass layer
-        return !layer.tilemapLayer.hasTileAt(tileX, tileY);
-      });
-
-      if (noOtherTile) {
-        const { x: worldX, y: worldY } = this.fieldMapTileMap.tileToWorldXY(tileX, tileY);
-
-        const plant = this.add.sprite(worldX, worldY, "plant");
-
-        plant.setFrame(446);
-        plant.setOrigin(0, 0);
-        plant.scale = 3;
-        this.plantLayer.add(plant);
+  if (this.playerView) {
+    if (this.addPlantKey.isDown) {
+      const playerPosition = this.gridEngine.getPosition("player");
+      const tileX = playerPosition.x;
+      const tileY = playerPosition.y;
+  
+      // Get the grass layer
+      const grassLayer = this.fieldMapTileMap.layers[0].tilemapLayer;
+  
+      // Check if there's a grass tile at the character's position and it has the property 'plantable'
+      const grassTile = grassLayer.getTileAt(tileX, tileY);
+  
+      if (grassTile && grassTile.properties.plantable) {
+        // Check if there's no tile at the character's position in other layers
+        const noOtherTile = this.fieldMapTileMap.layers.every((layer, index) => {
+          if (index === 0) return true; // Skip the grass layer
+          return !layer.tilemapLayer.hasTileAt(tileX, tileY);
+        });
+  
+        if (noOtherTile) {
+          const { x: worldX, y: worldY } = this.fieldMapTileMap.tileToWorldXY(tileX, tileY);
+  
+          const plant = this.add.sprite(worldX, worldY, "plant");
+  
+          plant.setFrame(446);
+          plant.setOrigin(0, 0);
+          plant.scale = 3;
+          this.plantLayer.add(plant);
+        }
       }
     }
-  }
-
-  if (removePlantKey.isDown) {
-    const playerPosition = this.gridEngine.getPosition("player");
-    const { x: worldX, y: worldY } = this.fieldMapTileMap.tileToWorldXY(playerPosition.x, playerPosition.y);
-
-    // Find all overlapping plants
-    const plantsToRemove = this.plantLayer.list.filter((plant) => {
-      const distance = Phaser.Math.Distance.Between(plant.x, plant.y, worldX, worldY);
-      return distance < (16 * 3) / 2;
-    });
-
-    // Remove all the overlapping plants
-    plantsToRemove.forEach((plant) => {
-      plant.destroy();
-    });
-  }
   
-  if (cursors.left.isDown) {
-    this.agent.moveAndCheckCollision("left", this.fieldMapTileMap);
-  } else if (cursors.right.isDown) {
-    this.agent.moveAndCheckCollision("right", this.fieldMapTileMap);
-  } else if (cursors.up.isDown) {
-    this.agent.moveAndCheckCollision("up", this.fieldMapTileMap);
-  } else if (cursors.down.isDown) {
-    this.agent.moveAndCheckCollision("down", this.fieldMapTileMap);
+    if (this.removePlantKey.isDown) {
+      const playerPosition = this.gridEngine.getPosition("player");
+      const { x: worldX, y: worldY } = this.fieldMapTileMap.tileToWorldXY(playerPosition.x, playerPosition.y);
+  
+      // Find all overlapping plants
+      const plantsToRemove = this.plantLayer.list.filter((plant) => {
+        const distance = Phaser.Math.Distance.Between(plant.x, plant.y, worldX, worldY);
+        return distance < (16 * 3) / 2;
+      });
+  
+      // Remove all the overlapping plants
+      plantsToRemove.forEach((plant) => {
+        plant.destroy();
+      });
+    }
+    
+    if (this.cursors.left.isDown) {
+      this.agent.moveAndCheckCollision("left", this.fieldMapTileMap);
+    } else if (this.cursors.right.isDown) {
+      this.agent.moveAndCheckCollision("right", this.fieldMapTileMap);
+    } else if (this.cursors.up.isDown) {
+      this.agent.moveAndCheckCollision("up", this.fieldMapTileMap);
+    } else if (this.cursors.down.isDown) {
+      this.agent.moveAndCheckCollision("down", this.fieldMapTileMap);
+    }
+  }
+  else if (!this.playerView) {
+    this.controls.update(delta);
   }
   
 };


### PR DESCRIPTION
What's been added/modified:

- Removed re-adding the keyboard keys on every update
- Added an event listener that checks for the C key being pressed
- Presing 'C' toggles between player view and observer view. Use the cursor keys to move the camera around and Q/E to zoom in & out.

***Known bug:** switching from player -> observer -> player -> observer the cursor keys stop working but Q/E still work fine.